### PR TITLE
Fix registration API call and exception status

### DIFF
--- a/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/services/UserService.java
+++ b/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/services/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
     public User findById(Long id) {
         UserSpringSecurity userSpringSecurity = authenticated();
         if(!Objects.nonNull(userSpringSecurity) || !userSpringSecurity.hasRole(ProfileEnum.ADMIN) && !id.equals(userSpringSecurity.getId())) {
-            throw new AuthorizationException("Accsess denied!");
+            throw new AuthorizationException("Access denied!");
         }
 
         Optional<User> user = this.userRepository.findById(id);

--- a/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/services/exceptions/DataBindingViolationException.java
+++ b/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/services/exceptions/DataBindingViolationException.java
@@ -4,7 +4,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(value = HttpStatus.NOT_FOUND)
+@ResponseStatus(value = HttpStatus.CONFLICT)
 public class DataBindingViolationException extends DataIntegrityViolationException {
 
     public DataBindingViolationException(String message) {

--- a/todosimple-project/todosimple-frontend/src/app/register/page.jsx
+++ b/todosimple-project/todosimple-frontend/src/app/register/page.jsx
@@ -16,7 +16,6 @@ export default function RegisterPage() {
       await api.post("/user", {
         username,
         password,
-        user_profile: "1", 
       });
       alert("Usuário criado com sucesso!");
       router.push("/login");


### PR DESCRIPTION
## Summary
- correct user registration request
- set proper HTTP status for `DataBindingViolationException`
- fix typo in authorization message

## Testing
- `./mvnw test -q` *(fails: Failed to fetch)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f4249df4c8329862d13abb23d50af