### PR TITLE
Add unit and controller tests

### DIFF
--- a/todosimple-project/todosimple-backend/src/test/java/com/vitorazevedo/todosimple/controllers/TaskControllerTest.java
+++ b/todosimple-project/todosimple-backend/src/test/java/com/vitorazevedo/todosimple/controllers/TaskControllerTest.java
@@ -1,0 +1,49 @@
+package com.vitorazevedo.todosimple.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vitorazevedo.todosimple.models.Task;
+import com.vitorazevedo.todosimple.services.TaskService;
+
+@WebMvcTest(TaskController.class)
+@ExtendWith(SpringExtension.class)
+public class TaskControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TaskService taskService;
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void createReturnsLocation() throws Exception {
+        Task task = new Task();
+        task.setDescription("test");
+        task.setId(4L);
+        when(taskService.create(any(Task.class))).thenAnswer(i -> {
+            Task t = i.getArgument(0);
+            t.setId(4L);
+            return t;
+        });
+
+        mockMvc.perform(post("/task")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(task)))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", "http://localhost/task/4"));
+    }
+}

--- a/todosimple-project/todosimple-backend/src/test/java/com/vitorazevedo/todosimple/controllers/UserControllerTest.java
+++ b/todosimple-project/todosimple-backend/src/test/java/com/vitorazevedo/todosimple/controllers/UserControllerTest.java
@@ -1,0 +1,54 @@
+package com.vitorazevedo.todosimple.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.vitorazevedo.todosimple.models.User;
+import com.vitorazevedo.todosimple.models.enums.ProfileEnum;
+import com.vitorazevedo.todosimple.security.UserSpringSecurity;
+import com.vitorazevedo.todosimple.services.UserService;
+
+@WebMvcTest(UserController.class)
+@ExtendWith(SpringExtension.class)
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void getLoggedUserReturnsUser() throws Exception {
+        Set<ProfileEnum> profiles = new HashSet<>();
+        profiles.add(ProfileEnum.USER);
+        UserSpringSecurity userSS = new UserSpringSecurity(1L, "john", "pass", profiles);
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("john");
+
+        when(userService.findById(1L)).thenReturn(user);
+
+        try (MockedStatic<UserService> mocked = mockStatic(UserService.class)) {
+            mocked.when(UserService::authenticated).thenReturn(userSS);
+
+            mockMvc.perform(get("/user/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.username").value("john"));
+        }
+    }
+}

--- a/todosimple-project/todosimple-backend/src/test/java/com/vitorazevedo/todosimple/services/TaskServiceTest.java
+++ b/todosimple-project/todosimple-backend/src/test/java/com/vitorazevedo/todosimple/services/TaskServiceTest.java
@@ -18,6 +18,7 @@ import com.vitorazevedo.todosimple.models.Task;
 import com.vitorazevedo.todosimple.models.User;
 import com.vitorazevedo.todosimple.models.enums.ProfileEnum;
 import com.vitorazevedo.todosimple.repositories.TaskRepository;
+import com.vitorazevedo.todosimple.services.exceptions.DataBindingViolationException;
 import com.vitorazevedo.todosimple.security.UserSpringSecurity;
 import com.vitorazevedo.todosimple.services.exceptions.ObjectNotFoundException;
 
@@ -77,6 +78,62 @@ public class TaskServiceTest {
             mocked.when(UserService::authenticated).thenReturn(userSS);
 
             assertThrows(ObjectNotFoundException.class, () -> taskService.findById(1L));
+        }
+}
+
+    @Test
+    void createAssociatesLoggedUser() {
+        User user = new User();
+        user.setId(3L);
+
+        Task task = new Task();
+        task.setDescription("desc");
+
+        when(userService.findById(3L)).thenReturn(user);
+        when(taskRepository.save(any(Task.class))).thenAnswer(i -> {
+            Task t = i.getArgument(0);
+            t.setId(10L);
+            return t;
+        });
+
+        Set<ProfileEnum> profiles = new HashSet<>();
+        profiles.add(ProfileEnum.USER);
+        UserSpringSecurity userSS = new UserSpringSecurity(3L, "john", "pass", profiles);
+
+        try (MockedStatic<UserService> mocked = mockStatic(UserService.class)) {
+            mocked.when(UserService::authenticated).thenReturn(userSS);
+            Task created = taskService.create(task);
+            assertEquals(10L, created.getId());
+            assertEquals(user, created.getUser());
+        }
+    }
+
+    @Test
+    void createWithoutAuthenticationThrows() {
+        Task task = new Task();
+        try (MockedStatic<UserService> mocked = mockStatic(UserService.class)) {
+            mocked.when(UserService::authenticated).thenReturn(null);
+            assertThrows(ObjectNotFoundException.class, () -> taskService.create(task));
+        }
+    }
+
+    @Test
+    void deleteWhenRepositoryFailsThrows() {
+        Task task = new Task();
+        task.setId(5L);
+        User owner = new User();
+        owner.setId(5L);
+        task.setUser(owner);
+        when(taskRepository.findById(5L)).thenReturn(Optional.of(task));
+        doThrow(new RuntimeException("fail")).when(taskRepository).deleteById(5L);
+
+        Set<ProfileEnum> profiles = new HashSet<>();
+        profiles.add(ProfileEnum.USER);
+        UserSpringSecurity userSS = new UserSpringSecurity(5L, "john", "pass", profiles);
+
+        try (MockedStatic<UserService> mocked = mockStatic(UserService.class)) {
+            mocked.when(UserService::authenticated).thenReturn(userSS);
+            assertThrows(DataBindingViolationException.class, () -> taskService.delete(5L));
         }
     }
 }

--- a/todosimple-project/todosimple-backend/src/test/java/com/vitorazevedo/todosimple/services/UserServiceTest.java
+++ b/todosimple-project/todosimple-backend/src/test/java/com/vitorazevedo/todosimple/services/UserServiceTest.java
@@ -1,0 +1,104 @@
+package com.vitorazevedo.todosimple.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import com.vitorazevedo.todosimple.models.User;
+import com.vitorazevedo.todosimple.models.dto.UserCreateDTO;
+import com.vitorazevedo.todosimple.models.dto.UserUpdateDTO;
+import com.vitorazevedo.todosimple.models.enums.ProfileEnum;
+import com.vitorazevedo.todosimple.repositories.UserRepository;
+import com.vitorazevedo.todosimple.services.exceptions.DataBindingViolationException;
+import com.vitorazevedo.todosimple.services.exceptions.ObjectNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void createEncodesPasswordAndAddsUserProfile() {
+        User user = new User();
+        user.setUsername("john");
+        user.setPassword("pass");
+
+        when(passwordEncoder.encode("pass")).thenReturn("encoded");
+        when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArgument(0));
+
+        User created = userService.create(user);
+
+        assertNull(created.getId());
+        assertEquals("encoded", created.getPassword());
+        assertTrue(created.getProfiles().contains(ProfileEnum.USER));
+        verify(userRepository).save(created);
+    }
+
+    @Test
+    void updateChangesPassword() {
+        User existing = new User();
+        existing.setId(1L);
+        existing.setPassword("old");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(passwordEncoder.encode("new")).thenReturn("encodedNew");
+        when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArgument(0));
+
+        User update = new User();
+        update.setId(1L);
+        update.setPassword("new");
+
+        User updated = userService.update(update);
+        assertEquals("encodedNew", updated.getPassword());
+        verify(userRepository).save(updated);
+    }
+
+    @Test
+    void deleteHandlesRepositoryException() {
+        User user = new User();
+        user.setId(2L);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
+        doThrow(new RuntimeException("constraint"))
+            .when(userRepository).deleteById(2L);
+
+        assertThrows(DataBindingViolationException.class, () -> userService.delete(2L));
+    }
+
+    @Test
+    void fromDTOCreatesUser() {
+        UserCreateDTO dto = new UserCreateDTO();
+        dto.setUsername("john");
+        dto.setPassword("secret");
+
+        User user = userService.fromDTO(dto);
+        assertEquals("john", user.getUsername());
+        assertEquals("secret", user.getPassword());
+    }
+
+    @Test
+    void fromDTOUpdatesUser() {
+        UserUpdateDTO dto = new UserUpdateDTO();
+        dto.setId(5L);
+        dto.setPassword("secret");
+
+        User user = userService.fromDTO(dto);
+        assertEquals(5L, user.getId());
+        assertEquals("secret", user.getPassword());
+    }
+}


### PR DESCRIPTION
## Summary
- expand backend test coverage
- add UserService tests for create, update, delete and DTO helpers
- extend TaskService tests to cover create and delete paths
- create UserController and TaskController WebMvc tests

## Testing
- `./mvnw -q test` *(fails: "wget: Failed to fetch" due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_683f4d1ce29c8329b91fa4eb290bcc5c