### PR TITLE
Add MVC tests for Task and User controllers

### DIFF
--- a/todosimple-project/todosimple-backend/src/test/java/com/vitorazevedo/todosimple/controllers/UserControllerTest.java
+++ b/todosimple-project/todosimple-backend/src/test/java/com/vitorazevedo/todosimple/controllers/UserControllerTest.java
@@ -13,10 +13,14 @@ import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vitorazevedo.todosimple.models.User;
+import com.vitorazevedo.todosimple.models.dto.UserCreateDTO;
+import com.vitorazevedo.todosimple.models.dto.UserUpdateDTO;
 import com.vitorazevedo.todosimple.models.enums.ProfileEnum;
 import com.vitorazevedo.todosimple.security.UserSpringSecurity;
 import com.vitorazevedo.todosimple.services.UserService;
@@ -30,6 +34,8 @@ public class UserControllerTest {
 
     @MockBean
     private UserService userService;
+
+    private ObjectMapper mapper = new ObjectMapper();
 
     @Test
     void getLoggedUserReturnsUser() throws Exception {
@@ -50,5 +56,64 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.id").value(1))
                 .andExpect(jsonPath("$.username").value("john"));
         }
+    }
+
+    @Test
+    void getUserByIdReturnsUser() throws Exception {
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("john");
+        when(userService.findById(1L)).thenReturn(user);
+
+        mockMvc.perform(get("/user/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.username").value("john"));
+    }
+
+    @Test
+    void createUserReturnsLocation() throws Exception {
+        UserCreateDTO dto = new UserCreateDTO();
+        dto.setUsername("john");
+        dto.setPassword("secret123");
+        User user = new User();
+        user.setUsername("john");
+        user.setPassword("secret123");
+        when(userService.fromDTO(any(UserCreateDTO.class))).thenReturn(user);
+        when(userService.create(any(User.class))).thenAnswer(i -> {
+            User u = i.getArgument(0);
+            u.setId(2L);
+            return u;
+        });
+
+        mockMvc.perform(post("/user")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(dto)))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", "http://localhost/user/2"));
+    }
+
+    @Test
+    void updateUserReturnsNoContent() throws Exception {
+        UserUpdateDTO dto = new UserUpdateDTO();
+        dto.setPassword("newpass");
+        User user = new User();
+        user.setId(1L);
+        user.setPassword("newpass");
+        when(userService.fromDTO(any(UserUpdateDTO.class))).thenReturn(user);
+        doNothing().when(userService).update(any(User.class));
+
+        mockMvc.perform(put("/user/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(dto)))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deleteUserReturnsNoContent() throws Exception {
+        doNothing().when(userService).delete(1L);
+
+        mockMvc.perform(delete("/user/1"))
+            .andExpect(status().isNoContent());
     }
 }


### PR DESCRIPTION
## Summary
- extend TaskControllerTest for get, list, update and delete
- expand UserControllerTest to cover CRUD endpoints

## Testing
- `./mvnw -q test` *(fails: Failed to fetch ...)*

------
https://chatgpt.com/codex/tasks/task_e_68405003902c83298ac238a1d7c73e0a