### PR TITLE
Add Swagger documentation

### DIFF
--- a/todosimple-project/todosimple-backend/pom.xml
+++ b/todosimple-project/todosimple-backend/pom.xml
@@ -128,7 +128,14 @@
       <version>0.11.5</version>
       <scope>runtime</scope>
     </dependency>
-    
+
+    <!-- Swagger/OpenAPI -->
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-ui</artifactId>
+      <version>1.6.14</version>
+    </dependency>
+
   </dependencies>
 
 

--- a/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/configs/OpenApiConfig.java
+++ b/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/configs/OpenApiConfig.java
@@ -1,0 +1,14 @@
+package com.vitorazevedo.todosimple.configs;
+
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.security.SecuritySchemeType;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "ToDoSimple API", version = "1.0", description = "Documentation of ToDoSimple REST API"))
+@SecurityScheme(name = "bearerAuth", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
+public class OpenApiConfig {
+}

--- a/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/controllers/AuthController.java
+++ b/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/controllers/AuthController.java
@@ -1,0 +1,30 @@
+package com.vitorazevedo.todosimple.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.vitorazevedo.todosimple.models.User;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+@RestController
+public class AuthController {
+
+    @PostMapping("/login")
+    @Operation(
+        summary = "Authenticate user",
+        description = "Returns a JWT token in the Authorization header on success",
+        requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = User.class))),
+        responses = {
+            @ApiResponse(responseCode = "200", description = "Authenticated")
+        }
+    )
+    public ResponseEntity<Void> login() {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/controllers/TaskController.java
+++ b/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/controllers/TaskController.java
@@ -18,6 +18,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
 import com.vitorazevedo.todosimple.models.Task;
 import com.vitorazevedo.todosimple.models.projection.TaskProjection;
 import com.vitorazevedo.todosimple.services.TaskService;
@@ -31,12 +36,18 @@ public class TaskController {
     private TaskService taskService;
 
     @GetMapping("/{id}")
-    public ResponseEntity<Task> getTaskById(@PathVariable Long id) {
+    @Operation(summary = "Find task by id",
+        security = @SecurityRequirement(name = "bearerAuth"),
+        responses = {@ApiResponse(responseCode = "200", description = "Task found")})
+    public ResponseEntity<Task> getTaskById(@Parameter(description = "Task id") @PathVariable Long id) {
         Task obj = this.taskService.findById(id);
         return ResponseEntity.ok(obj);
     }
 
     @GetMapping("/user")
+    @Operation(summary = "List tasks of logged user",
+        security = @SecurityRequirement(name = "bearerAuth"),
+        responses = {@ApiResponse(responseCode = "200", description = "List of tasks")})
     public ResponseEntity<List<TaskProjection>> findAllByUser() {
         List<TaskProjection> list = this.taskService.findAllByUser();
         return ResponseEntity.ok(list);
@@ -44,6 +55,9 @@ public class TaskController {
 
     @PostMapping
     @Validated
+    @Operation(summary = "Create new task",
+        security = @SecurityRequirement(name = "bearerAuth"),
+        responses = {@ApiResponse(responseCode = "201", description = "Task created")})
     public ResponseEntity<Void> create(@Validated @RequestBody Task obj) {
         this.taskService.create(obj);
         URI uri = ServletUriComponentsBuilder.fromCurrentRequest()
@@ -53,15 +67,21 @@ public class TaskController {
         return ResponseEntity.created(uri).build();
         }
 
-    @PutMapping("/{id}")   
-    public ResponseEntity<Void> update(@Valid @RequestBody Task obj, @PathVariable Long id) {
+    @PutMapping("/{id}")
+    @Operation(summary = "Update task",
+        security = @SecurityRequirement(name = "bearerAuth"),
+        responses = {@ApiResponse(responseCode = "204", description = "Task updated")})
+    public ResponseEntity<Void> update(@Valid @RequestBody Task obj, @Parameter(description = "Task id") @PathVariable Long id) {
         obj.setId(id);
         this.taskService.update(obj);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
+    @Operation(summary = "Delete task",
+        security = @SecurityRequirement(name = "bearerAuth"),
+        responses = {@ApiResponse(responseCode = "204", description = "Task deleted")})
+    public ResponseEntity<Void> delete(@Parameter(description = "Task id") @PathVariable Long id) {
         this.taskService.delete(id);
         return ResponseEntity.noContent().build();
     }

--- a/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/models/dto/UserCreateDTO.java
+++ b/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/models/dto/UserCreateDTO.java
@@ -7,17 +7,22 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
+@Schema(description = "Data required to create a new user")
 public class UserCreateDTO {
     
     @NotBlank
     @Size(min = 2, max = 100)
+    @Schema(example = "johndoe")
     private String username;
 
     @NotBlank
     @Size(min = 8, max = 60)
+    @Schema(example = "mySecret123")
     private String password;
 
 }


### PR DESCRIPTION
## Summary
- integrate Springdoc for Swagger UI
- document JWT security scheme
- provide AuthController for login documentation
- annotate TaskController operations
- show usage of `@Schema` in `UserCreateDTO`

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68405878bae88329b0522a135575465f