### PR TITLE
Lower password min length

### DIFF
--- a/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/models/User.java
+++ b/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/models/User.java
@@ -47,7 +47,7 @@ public class User {
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Column(name = "password", nullable = false, length = 60)
     @NotBlank(message = "Password cannot be blank")
-    @Size(min = 8, max = 60)
+    @Size(min = 4, max = 60, message = "Password must contain at least 4 characters")
     private String password;
 
 

--- a/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/models/dto/UserCreateDTO.java
+++ b/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/models/dto/UserCreateDTO.java
@@ -21,7 +21,7 @@ public class UserCreateDTO {
     private String username;
 
     @NotBlank
-    @Size(min = 8, max = 60)
+    @Size(min = 4, max = 60, message = "Password must contain at least 4 characters")
     @Schema(example = "mySecret123")
     private String password;
 

--- a/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/models/dto/UserUpdateDTO.java
+++ b/todosimple-project/todosimple-backend/src/main/java/com/vitorazevedo/todosimple/models/dto/UserUpdateDTO.java
@@ -15,7 +15,7 @@ public class UserUpdateDTO {
     private Long id;
 
     @NotBlank
-    @Size(min = 8, max = 60)
+    @Size(min = 4, max = 60, message = "Password must contain at least 4 characters")
     private String password;
 
 }

--- a/todosimple-project/todosimple-frontend/src/app/register/page.jsx
+++ b/todosimple-project/todosimple-frontend/src/app/register/page.jsx
@@ -12,11 +12,15 @@ export default function RegisterPage() {
 
   const handleRegister = async (e) => {
     e.preventDefault();
+    if (password.length < 4) {
+      alert("Password must contain at least 4 characters");
+      return;
+    }
     try {
       await api.post("/user", {
         username,
         password,
-        user_profile: "1", 
+        user_profile: "1",
       });
       alert("Usuário criado com sucesso!");
       router.push("/login");


### PR DESCRIPTION
## Summary
- relax password length requirements to 4 characters on backend
- warn about short passwords on registration page

## Testing
- `npm --version`
- `node --version`
- `mvn -version`


------
https://chatgpt.com/codex/tasks/task_e_68422d983208832980a02236721eaa29