### PR TITLE
Add Docker Compose setup for full application

### DIFF
--- a/todosimple-project/docker-compose.yml
+++ b/todosimple-project/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+
+services:
+  mysqldb:
+    image: mysql:5.7
+    env_file: ./todosimple-backend/.env
+    ports:
+      - "${MYSQLDB_LOCAL_PORT:-3306}:${MYSQLDB_DOCKER_PORT:-3306}"
+    volumes:
+      - db-data:/var/lib/mysql
+
+  backend:
+    build:
+      context: ./todosimple-backend
+      dockerfile: Dockerfile
+    depends_on:
+      - mysqldb
+    env_file: ./todosimple-backend/.env
+    ports:
+      - "${SPRING_LOCAL_PORT:-8080}:${SPRING_DOCKER_PORT:-8080}"
+
+  frontend:
+    build: ./todosimple-frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=http://backend:${SPRING_DOCKER_PORT:-8080}
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add root docker compose file to run MySQL, Spring backend, and Next.js frontend together

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.3 from/to central: Network is unreachable)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fcb52afa08329b65811ba6761bc3b